### PR TITLE
support 'description' field for response data

### DIFF
--- a/pathitem.go
+++ b/pathitem.go
@@ -112,7 +112,14 @@ func addPathItem(reflector *openapi31.Reflector, pathItemSpec PathItemSpec) erro
 		if err != nil {
 			return err
 		}
-		oc.AddRespStructure(convertedResp, og.WithHTTPStatus(resp.status))
+
+		options := make([]og.ContentOption, 0)
+		options = append(options, og.WithHTTPStatus(resp.status))
+		if(resp.description != "") {
+			options = append(options, withDescription(resp.description))
+		}
+
+		oc.AddRespStructure(convertedResp, options...)
 	}
 
 	if err := reflector.AddOperation(oc); err != nil {
@@ -124,4 +131,10 @@ func addPathItem(reflector *openapi31.Reflector, pathItemSpec PathItemSpec) erro
 
 	return nil
 
+}
+
+func withDescription(description string) func(cu *og.ContentUnit) {
+	return func(cu *og.ContentUnit) {
+		cu.Description = description
+	}
 }

--- a/response.go
+++ b/response.go
@@ -6,11 +6,18 @@ func ResponseStatus(status int) responseOption {
 	}
 }
 
+func ResponseDescription(description string) responseOption {
+	return func(r *responseOptions) {
+		r.description = description
+	}
+}
+
 func (o *PathItemSpec) AddResponse(body any, opts ...responseOption) {
 
 	r := responseOptions{
 		status: 200,
 		body:   body,
+		description: "",
 	}
 	for _, opt := range opts {
 		opt(&r)
@@ -24,4 +31,5 @@ type responseOption func(r *responseOptions)
 type responseOptions struct {
 	body   any
 	status int
+	description string
 }


### PR DESCRIPTION
Added a 'ResponseDescription()' function in `response.go`.
You can add a description text for a response data like following:

```
type ErrorResponse struct {
	Message string `json:"message"`
}

AddResponse(ErrorResponse{}, ResponseStatus(http.StatusConflict), ResponseDescription("Duplicate user id"))
```

This code will generate openapi yaml like:

```
        "409":
          content:
            application/json:
              schema:
                properties:
                  message:
                    type: string
                type: object
          description: Duplicate user id
```