### PR TITLE
feat: support description

### DIFF
--- a/document.go
+++ b/document.go
@@ -9,13 +9,13 @@ import (
 // Doc represents the root of an OpenAPIv3.1 document.
 type Doc struct {
 	reflector *openapi31.Reflector
-	// handlerNameToOptionsにあるoperationKeyに対応するPathItemSpecをもちます。
+	// maps a pathItemSpecKey in handlerToPathItems to the corresponding PathItemSpec.
 	pathItemSpecs map[pathItemSpecKey]PathItemSpec
 	// Associates each handler with the path items that share the handler.
 	handlerToPathItems map[string][]pathItemSpecKey
 }
 
-// MakeDoc returns *Doc.
+// MakeDoc returns [Doc].
 func MakeDoc() Doc {
 	return Doc{
 		reflector:          openapi31.NewReflector(),
@@ -30,7 +30,7 @@ func (d Doc) AssocRoutesInfo(routes gin.RoutesInfo) error {
 
 		keys, ok := d.handlerToPathItems[route.Handler]
 		if !ok || len(keys) == 0 {
-			// Open API定義に記述しないハンドラを無視します。
+			// Skip the handlers that do not contain Open API spec.
 			continue
 		}
 		var key pathItemSpecKey
@@ -58,7 +58,7 @@ func (d Doc) AssocRoutesInfo(routes gin.RoutesInfo) error {
 	return nil
 }
 
-// MarshalYAML returns the YAML encoding of Doc.
+// MarshalYAML returns the YAML encoding of [Doc].
 func (d Doc) MarshalYAML() ([]byte, error) {
 	return d.reflector.Spec.MarshalYAML()
 }

--- a/example_test.go
+++ b/example_test.go
@@ -12,7 +12,7 @@ import (
 
 type AddPetRequest struct {
 	ID         int    `json:"id" binding:"required"`
-	CustomerID string `header:"customerId"`
+	CustomerID string `header:"customerId" description:"identifies a customer"`
 	TrackingID string `cookie:"trackingId"`
 }
 
@@ -134,9 +134,11 @@ func Example() {
 	//         name: trackingId
 	//         schema:
 	//           type: string
-	//       - in: header
+	//       - description: identifies a customer
+	//         in: header
 	//         name: customerId
 	//         schema:
+	//           description: identifies a customer
 	//           type: string
 	//       requestBody:
 	//         content:

--- a/tag.go
+++ b/tag.go
@@ -12,7 +12,7 @@ func makeOpenAPITag(sf reflect.StructTag, ignoreParams map[string]bool) reflect.
 	if v, ok := sf.Lookup("uri"); ok && !ignoreParams[v] {
 		res += fmt.Sprintf(`path:"%s" `, v)
 	}
-	for _, keyword := range []string{"query", "json", "form", "header", "cookie", "example", "pattern"} {
+	for _, keyword := range []string{"query", "json", "form", "header", "cookie", "example", "pattern", "description"} {
 		if v, ok := sf.Lookup(keyword); ok {
 			res += fmt.Sprintf(`%s:"%s" `, keyword, v)
 		}


### PR DESCRIPTION
This patch allows developers to put a [`description`](https://spec.openapis.org/oas/v3.1.0.html#fixed-fields-9) entry in a Open API parameter by annotate a Go struct field with `description: <text>`.